### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -1,5 +1,7 @@
 ---
 name: Lint YAML
+permissions:
+  contents: read
 
 "on":
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JanWelker/homelab/security/code-scanning/4](https://github.com/JanWelker/homelab/security/code-scanning/4)

In general, to fix this issue you add a `permissions` block either at the top level of the workflow (so it applies to all jobs) or under the specific job, and restrict the `GITHUB_TOKEN` to the minimum required scopes. For a read-only linting job that only checks YAML files, `contents: read` is sufficient.

The best fix here, without changing existing functionality, is to add a workflow-wide `permissions` block after the `name:` field (or before `jobs:`). This will ensure that `actions/checkout` and the rest of the steps run with a token limited to reading repository contents. No other scopes (like `pull-requests`, `issues`, or `contents: write`) are needed based on the shown code.

Concretely, in `.github/workflows/lint-yaml.yaml`, between line 2 (`name: Lint YAML`) and line 4 (`"on":`), insert:

```yaml
permissions:
  contents: read
```

No new imports, methods, or additional definitions are needed, because this is just a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
