### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -1,5 +1,7 @@
 ---
 name: Lint Python
+permissions:
+  contents: read
 
 "on":
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JanWelker/homelab/security/code-scanning/3](https://github.com/JanWelker/homelab/security/code-scanning/3)

In general, fix this by explicitly specifying `permissions` for the workflow or for the specific job(s), limiting the `GITHUB_TOKEN` to the minimum necessary scopes. For a lint-only workflow that just checks out code and runs local tools, `contents: read` is sufficient and often even `permissions: {}` can work, but `contents: read` is a safe, clear minimal starting point and matches the CodeQL suggestion.

The best fix here without changing functionality is to add a `permissions` block at the workflow root (so it applies to all jobs) right after the `name: Lint Python` line. This will set `contents: read` for the entire workflow. No code changes to steps are needed, and no additional imports or tools are required. Concretely, in `.github/workflows/lint-python.yaml`, insert:

```yaml
name: Lint Python
permissions:
  contents: read
```

above the `"on":` key. This maintains current behavior while constraining token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
