### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-markdown.yaml
+++ b/.github/workflows/lint-markdown.yaml
@@ -1,5 +1,7 @@
 ---
 name: Lint Markdown
+permissions:
+  contents: read
 
 "on":
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JanWelker/homelab/security/code-scanning/2](https://github.com/JanWelker/homelab/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block to the workflow or specific job, granting only the minimal access that the job requires. For a pure lint job that only checks out code and runs local tools, `contents: read` is typically sufficient.

For this specific workflow, the cleanest minimal-change fix is to add a `permissions` section at the root (top-level, alongside `name` and `on`) so that it applies to all jobs in the file. We will set `contents: read`, which allows the checkout action to function while avoiding any write permissions. No additional imports or methods are required because this is a YAML configuration change only. Concretely, in `.github/workflows/lint-markdown.yaml`, we will insert:

```yaml
permissions:
  contents: read
```

between the `name: Lint Markdown` line and the `"on":` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
