### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-ansible.yaml
+++ b/.github/workflows/lint-ansible.yaml
@@ -14,6 +14,8 @@ name: Lint Ansible
 jobs:
   ansible-lint:
     name: Ansible
+    permissions:
+      contents: read
     runs-on: arc-runner-set
     container: python:3.14-slim
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/JanWelker/homelab/security/code-scanning/1](https://github.com/JanWelker/homelab/security/code-scanning/1)

In general, the fix is to explicitly declare minimal GITHUB_TOKEN permissions for this workflow or for the specific job. Since this workflow only checks out code and runs Ansible linting, it only needs read access to repository contents. We can either define `permissions:` at the top level (applying to all jobs) or for the `ansible-lint` job only; here, setting it at the job level near the flagged line is the most localized change.

Concretely, in `.github/workflows/lint-ansible.yaml`, under `jobs:`, within the `ansible-lint` job and before `runs-on: arc-runner-set`, add a `permissions:` block setting `contents: read`. This keeps existing functionality intact while constraining the implicit `GITHUB_TOKEN` to read-only repository contents. No extra imports, tools, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
