### PR TITLE
fix(renovate): improve dependency coverage

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,12 @@
       "matchFileNames": [
         "payload/workloads/**"
       ],
+      "matchManagers": [
+        "kubernetes",
+        "argocd",
+        "helm-values",
+        "dockerfile"
+      ],
       "groupName": "Workloads",
       "addLabels": [
         "application"
@@ -56,7 +62,8 @@
         "ansible-lint",
         "pylint",
         "yamllint",
-        "mkdocs-material"
+        "mkdocs-material",
+        "tftpy"
       ],
       "groupName": "Dev Tooling",
       "automerge": true,
@@ -70,6 +77,7 @@
       "matchManagers": [
         "ansible",
         "github-actions",
+        "pre-commit",
         "custom.regex"
       ],
       "groupName": "DevOps",
@@ -173,16 +181,6 @@
       "depNameTemplate": "syslinux",
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "geneh/syslinux"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^ansible/templates/.*\\.j2$/"
-      ],
-      "matchStrings": [
-        "image:\\s*['\"]?(?<depName>[^:\"'\\s]+):(?<currentValue>[a-zA-Z0-9_.-]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"
-      ],
-      "datasourceTemplate": "docker"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
- Add dockerfile manager to Workloads group so the documentation Dockerfile (nginxinc/nginx-unprivileged) is batched with workload updates
- Add tftpy to Python Tooling group to avoid individual PRs
- Add pre-commit manager to DevOps group so .pre-commit-config.yaml hook revisions are batched instead of generating individual PRs
- Remove dead custom.regex for ansible/templates/*.j2 — no templates contain image: references so the rule never matched anything