### PR TITLE
fix(ci): skip claude-review on workflow file changes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths-ignore:
+      - '.github/workflows/**'
 
 jobs:
   claude-review:
@@ -41,4 +37,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary

- Adds `paths-ignore: ['.github/workflows/**']` to the `pull_request` trigger in `claude-code-review.yml`
- Prevents the claude-review job from running on PRs that only modify workflow files (e.g. Renovate dependency bumps for `actions/checkout`)

## Why

When a PR modifies the workflow file itself, `claude-code-action`'s GitHub App token exchange fails with a 401 because GitHub requires the workflow to be identical to the version on the default branch. This is a security measure that can't be worked around — so the cleanest fix is to not trigger the job on those PRs at all.

Observed on: https://github.com/JanWelker/homelab/actions/runs/25131201225/job/73657604981?pr=278

## Test plan

- [ ] Merge this PR first
- [ ] Merge the Renovate `actions/checkout` bump (PR #278) — the claude-review check should be skipped (not fail)
- [ ] Confirm claude-review still runs on normal code PRs